### PR TITLE
task 7 implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-node_modules
+product-service/node_modules
 /.pnp
 .pnp.js
 
@@ -14,6 +14,7 @@ build
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/authorization-service/.env
+++ b/authorization-service/.env
@@ -1,0 +1,1 @@
+jegius=TEST_PASSWORD

--- a/authorization-service/handler.ts
+++ b/authorization-service/handler.ts
@@ -1,0 +1,4 @@
+import {basicAuthorizerHandler} from "./handlers/basicAuthorizer/basicAuthorizer";
+import {APIGatewayProxyHandler} from "aws-lambda";
+
+export const basicAuthorizer: APIGatewayProxyHandler = basicAuthorizerHandler;

--- a/authorization-service/handlers/basicAuthorizer/basicAuthorizer.ts
+++ b/authorization-service/handlers/basicAuthorizer/basicAuthorizer.ts
@@ -1,0 +1,42 @@
+import 'source-map-support/register';
+
+export const basicAuthorizerHandler: any = async (event, _, callback) => {
+    if (event['type'] !== 'REQUEST') {
+        callback('Unauthorized');
+    }
+
+    try {
+        const {queryStringParameters: {token}} = event;
+        const buffer = Buffer.from(token, 'base64');
+        const [username, password] = buffer.toString('utf-8').split(':');
+
+        console.log(`username: ${username} and password: ${password}`);
+
+        const storedUserPassword = process.env[username];
+        const effect = !storedUserPassword || storedUserPassword !== password
+            ? 'Deny'
+            : 'Allow';
+
+        const policy = generatePolicy(token, event.methodArn, effect);
+
+        callback(null, policy)
+    } catch (e) {
+        callback(`Unauthorized: ${e.message}`)
+    }
+};
+
+function generatePolicy(principalId, resource, effect = 'Allow') {
+    return {
+        principalId,
+        policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Action: 'execute-api:Invoke',
+                    Effect: effect,
+                    Resource: resource
+                }
+            ]
+        }
+    }
+}

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Serverless webpack example using Typescript",
+  "main": "handler.js",
+  "scripts": {
+    "test": "jest",
+    "deploy": "sls deploy"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.792.0",
+    "source-map-support": "^0.5.10"
+  },
+  "devDependencies": {
+    "@babel/preset-typescript": "^7.12.1",
+    "@types/aws-lambda": "^8.10.17",
+    "@types/node": "^10.12.18",
+    "@types/serverless": "^1.72.5",
+    "fork-ts-checker-webpack-plugin": "^3.0.1",
+    "jest": "^26.6.1",
+    "serverless-webpack": "^5.2.0",
+    "serverless-dotenv-plugin": "^3.1.0",
+    "ts-loader": "^5.3.3",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.2.4",
+    "webpack": "^4.29.0",
+    "webpack-node-externals": "^1.7.2"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/authorization-service/serverless.ts
+++ b/authorization-service/serverless.ts
@@ -1,0 +1,57 @@
+import {Serverless} from "serverless/plugins/aws/provider/awsProvider";
+
+const serverlessConfiguration: Serverless = {
+    service: {
+        name: 'authorization-service',
+    },
+    frameworkVersion: '2',
+    custom: {
+        webpack: {
+            webpackConfig: './webpack.config.js',
+            includeModules: true
+        }
+    },
+    plugins: [
+        'serverless-webpack',
+        'serverless-dotenv-plugin'
+    ],
+    provider: {
+        name: 'aws',
+        runtime: 'nodejs12.x',
+        iamRoleStatements: [
+            {
+                Effect: "Allow",
+                Action: ["s3:uploadToBucket"],
+                Resource: "arn:aws:s3:::node-aws-import-service"
+            },
+            {
+                Effect: "Allow",
+                Action: ["s3:*"],
+                Resource: "arn:aws:s3:::node-aws-import-service/*"
+            },
+            {
+                Effect: "Allow",
+                Action: "sqs:*",
+                Resource: ['${cf:product-service-${self:provider.stage}.SQSQueueArn}']
+            }
+        ],
+        stage: 'dev',
+        region: 'eu-west-1',
+        apiGateway: {
+            minimumCompressionSize: 1024,
+        },
+        environment: {
+            AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+            Bucket: 'node-aws-import-service',
+            Prefix: 'uploaded/',
+            SQS_URL: '${cf:product-service-${self:provider.stage}.SQSQueueUrl}',
+        },
+    },
+    functions: {
+        basicAuthorizer: {
+            handler: 'handler.basicAuthorizer',
+        }
+    }
+}
+
+module.exports = serverlessConfiguration;

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/authorization-service/webpack.config.js
+++ b/authorization-service/webpack.config.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'cheap-module-eval-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [],
+};

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -52,7 +52,7 @@ const serverlessConfiguration: Serverless = {
             events: [
                 {
                     http: {
-                        method: 'get',
+                        method: 'put',
                         path: 'import',
                         request: {
                             parameters: {
@@ -62,6 +62,13 @@ const serverlessConfiguration: Serverless = {
                             }
                         },
                         cors: true,
+                        authorizer: {
+                            name: 'authorization-service',
+                            arn: 'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:basicAuthorizer',
+                            resultTtlInSeconds: 0,
+                            identitySource: 'method.request.header.Authorization',
+                            type: 'token'
+                        }
                     }
                 }
             ]

--- a/product-service/dao/daoAPI.ts
+++ b/product-service/dao/daoAPI.ts
@@ -26,6 +26,7 @@ export interface Product {
     imageurl: string;
 }
 
+
 export abstract class DaoObject<T> implements Dao<T> {
     private readonly dbOptions = {
         ...process.env,

--- a/product-service/dao/daoAPI.ts
+++ b/product-service/dao/daoAPI.ts
@@ -26,7 +26,6 @@ export interface Product {
     imageurl: string;
 }
 
-
 export abstract class DaoObject<T> implements Dao<T> {
     private readonly dbOptions = {
         ...process.env,

--- a/product-service/dao/product/queries.ts
+++ b/product-service/dao/product/queries.ts
@@ -17,5 +17,4 @@ WITH product AS (
      )
 SELECT product.product_id as id, product.description, product.title, product.price, product.image_url as imageurl, stock.count
 FROM product join stock on stock.product_id = product.product_id
-
 `;


### PR DESCRIPTION
- [x] 1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] 3 - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.

- [ ] 5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

https://d20wes0bg8lspj.cloudfront.net/admin/products
password = TEST_PASSWORD